### PR TITLE
Fix for error when recalling yagames.init

### DIFF
--- a/yagames/helpers/helper.lua
+++ b/yagames/helpers/helper.lua
@@ -46,7 +46,11 @@ function M.wrap_for_promise(then_callback)
 end
 
 function M.async_call(cb)
-    timer.delay(0, false, cb)
+    if cb then
+        timer.delay(0, false, function (self, handle)
+            cb(self)           
+        end)
+    end
 end
 
 return M


### PR DESCRIPTION
If you call **yagames.init** again after initialization, then the **err** parameter will be a number.

Because the callback is called through the **timer** and instead of **err** it gets the **handle** of the **timer**
https://github.com/indiesoftby/defold-yagames/blob/aee6043a1c25df1dc9219a5e9a050833e6c2e78a/yagames/yagames.lua#L61-L65
https://github.com/indiesoftby/defold-yagames/blob/aee6043a1c25df1dc9219a5e9a050833e6c2e78a/yagames/helpers/helper.lua#L48-L50

